### PR TITLE
Use last year contributions according to homebrew tooling for initial voting

### DIFF
--- a/Bootstrapping-Gem.coop-Governance.md
+++ b/Bootstrapping-Gem.coop-Governance.md
@@ -13,7 +13,7 @@ These are the steps that will be followed to bootstrap this governance process
 - Mike McQuaid makes the governance repository public
 - Mike McQuaid will leave the GitHub organisation
 - Candidates for the Project Leader and Project Leadership Committee will put their names forward for election
-- A selection of those who made of RubyGems contributions in the last year will be given a vote
+- Everyone with RubyGems maintainer contributions in the last year (<https://mikemcquaid.com/rubygems-contribution-data-with-homebrews-tooling/>) will be given a vote
 - Someone will setup the voting using OpaVote, tally and announce the results
 - When a Project Leader and Project Leadership Committee have been appointed, they will in turn appoint the maintainers and, from them, the Technical Steering Committee
 - Everyone who voted will be made a Member and granted a vote in the following year


### PR DESCRIPTION
I'm not sure which contributor list is best to use for the initial voting.

Homebrew tooling takes several things into account in order to define "maintainer", not only commits, which is good. However, it seems to take into account all repositories in the organization, not just "critical" ones like the governance document mentions.

That said, it seems like the best available option, so let's use that.