### PR TITLE
Clarify distinction between gem.coop (the service) and Gem Cooperative (the group) and gem-coop (GitHub organization)

### DIFF
--- a/Bootstrapping-Gem.coop-Governance.md
+++ b/Bootstrapping-Gem.coop-Governance.md
@@ -1,6 +1,6 @@
-# Bootstrapping Gem.coop Governance
+# Bootstrapping Gem Cooperative Governance
 
-At the time of writing, there is not yet any formal governance of the Gem.coop project.
+At the time of writing, there is not yet any formal governance of the Gem Cooperative project.
 
 These are the steps that will be followed to bootstrap this governance process
 
@@ -18,4 +18,4 @@ These are the steps that will be followed to bootstrap this governance process
 - When a Project Leader and Project Leadership Committee have been appointed, they will in turn appoint the maintainers and, from them, the Technical Steering Committee
 - Everyone who voted will be made a Member and granted a vote in the following year
 - Everyone else will be removed from the GitHub Organisation
-- The Gem.coop governance documents will apply from this point
+- The Gem Cooperative governance documents will apply from this point

--- a/Gem.coop-Governance.md
+++ b/Gem.coop-Governance.md
@@ -1,4 +1,4 @@
-# Gem.coop Governance
+# Gem Cooperative Governance
 
 ## 1. Definitions
 
@@ -9,24 +9,24 @@
 - AGM: Annual General Meeting
 - Majority: more than half of non-abstention votes cast.
 - Supermajority: two-thirds of non-abstention votes cast.
-- Primary repositories: the most important repositories in the Gem.coop organisation:
+- Primary repositories: the most important repositories in the gem-coop GitHub organisation:
   - [gem-coop/gem.coop](https://github.com/gem-coop/gem.coop) ([contributions](https://github.com/gem-coop/gem.coop/graphs/contributors))
 
 ## 2. Members
 
 1. New members (unless nominated as maintainers, see below) will be admitted by a majority of the PLC and added to the `gem-coop` organisation on GitHub.
 
-1. Members are expected to remain active within Gem.coop. Members who are not active maintainers or active committee members must affirm their continued interest in Gem.coop membership annually by voting on annual measures, even if voting abstention. Inactive, non-affirmed, non-voting members will be removed within 14 days after the annual meeting unless excused by the PLC.
+1. Members are expected to remain active within Gem Cooperative. Members who are not active maintainers or active committee members must affirm their continued interest in Gem Cooperative membership annually by voting on annual measures, even if voting abstention. Inactive, non-affirmed, non-voting members will be removed within 14 days after the annual meeting unless excused by the PLC.
 
-1. A member may be removed from Gem.coop by a majority of the PLC. A removed member may be reinstated by the usual admission process.
+1. A member may be removed from Gem Cooperative by a majority of the PLC. A removed member may be reinstated by the usual admission process.
 
-1. All members will follow the [Gem.coop's Code of Conduct](https://github.com/gem-coop/.github/blob/HEAD/CODE_OF_CONDUCT.md). Changes to the code of conduct must be approved by a majority of the PLC.
+1. All members will follow the [Gem Cooperative's Code of Conduct](https://github.com/gem-coop/.github/blob/HEAD/CODE_OF_CONDUCT.md). Changes to the code of conduct must be approved by a majority of the PLC.
 
 1. Members should abstain from voting when they have a conflict of interest not shared by other members. No one may be compelled to abstain from voting.
 
 ### 2.1. General Meetings of Members
 
-1. Gem.coop members will meet at the annual general meeting (AGM) in a manner determined by the PLC. The AGM date must be given with at least two months' advance notice.
+1. Gem Cooperative members will meet at the annual general meeting (AGM) in a manner determined by the PLC. The AGM date must be given with at least two months' advance notice.
 
 1. Any member can request additional general meetings of the members in the `#gem-coop-members` Slack channel. A general meeting may be called by either a majority vote of the PLC or a majority vote of the entire membership using Slack 👍 reactions. The membership must be given at least three weeks' notice of a general meeting.
 
@@ -47,13 +47,13 @@
 
 ## 3. Project Leadership Committee
 
-1. The financial administration of Gem.coop, organisation of the AGM, enforcement of the code of conduct and removal of members are performed by the PLC. The PLC will represent Gem.coop in all dealings with Open Collective.
+1. The financial administration of Gem Cooperative, organisation of the AGM, enforcement of the code of conduct and removal of members are performed by the PLC. The PLC will represent Gem Cooperative in all dealings with Open Collective.
 
-1. The PLC consists of three members, one of whom is the Project Leader. The other committee members are elected by Gem.coop members in a [Meek Single Transferable Vote](https://en.wikipedia.org/wiki/Counting_single_transferable_votes#Meek's_method) election using the Droop quota. Each PLC member will serve a term of two years or until the member's successor is elected. Any sudden vacancy in the PLC will be filled by the usual procedure for electing PLC members at the next general meeting, typically the next AGM.
+1. The PLC consists of three members, one of whom is the Project Leader. The other committee members are elected by Gem Cooperative members in a [Meek Single Transferable Vote](https://en.wikipedia.org/wiki/Counting_single_transferable_votes#Meek's_method) election using the Droop quota. Each PLC member will serve a term of two years or until the member's successor is elected. Any sudden vacancy in the PLC will be filled by the usual procedure for electing PLC members at the next general meeting, typically the next AGM.
 
 1. When a PLC seat is up for election or is vacant, any member may become a candidate for the PLC by providing a brief statement in the `#gem-coop-members` channel in Bundler Slack expressing relevant experience and intentions if elected no later than three weeks before the AGM. The PLC will maintain the candidate list until ballots are sent out one week before the AGM, during which time members should cast their votes. Candidates should deliver remarks in writing or verbally before or during the AGM but votes already cast are not changeable. The current PLC should vote on and publish a statement recommending their preferred candidates within the three-week period between the candidate deadline and the AGM.
 
-1. The PLC must report all minutes, participants in discussions and breakdowns of any votes cast to Gem.coop members in the gem-coop/governance GitHub repository no later than one week after the action has been taken. At the AGM, the PLC must present a summary of their activities and decisions since the last AGM. Financial statements can be viewed by anyone on the internet on [Gem.coop's OpenCollective](https://opencollective.com/gem-coop).
+1. The PLC must report all minutes, participants in discussions and breakdowns of any votes cast to Gem Cooperative members in the gem-coop/governance GitHub repository no later than one week after the action has been taken. At the AGM, the PLC must present a summary of their activities and decisions since the last AGM. Financial statements can be viewed by anyone on the internet on [The Gem Cooperative's OpenCollective](https://opencollective.com/gem-coop).
 
 1. No more than one employee of the same employer may serve on the PLC.
 
@@ -67,15 +67,15 @@
 
 1. All members of the PLC must meet at the AGM at least once per year. This will ideally be in person, or, alternatively, on a synchronous video call. For accessibility a synchronous text chat option should be available.
 
-1. The PLC will annually review the status of all members and remove members who did not vote in the AGM and then did not re-affirm a commitment to Gem.coop. Voting in the AGM confirms that a member wishes to remain active with the project. After the AGM, the PLC will ask the members who did not vote whether they wish to remain active with the project. The PLC removes any members who don't respond to this second request after three weeks.
+1. The PLC will annually review the status of all members and remove members who did not vote in the AGM and then did not re-affirm a commitment to Gem Cooperative. Voting in the AGM confirms that a member wishes to remain active with the project. After the AGM, the PLC will ask the members who did not vote whether they wish to remain active with the project. The PLC removes any members who don't respond to this second request after three weeks.
 
 1. A majority vote of the PLC will appoint the members of the TSC.
 
 ## 4. Project Leader
 
-1. The Project Leader will represent Gem.coop publicly, manage all day-to-day technical decisions, and resolve disputes related to the operation of Gem.coop between maintainers, members, other contributors, and users.
+1. The Project Leader will represent Gem Cooperative publicly, manage all day-to-day technical decisions, and resolve disputes related to the operation of Gem Cooperative between maintainers, members, other contributors, and users.
 
-1. The Project Leader will be elected every two years by Gem.coop members in a [Schulze Condorcet method](https://en.wikipedia.org/wiki/Schulze_method) (aka 'beatpath') election. The PLC will nominate at least one candidate for Project Leader. Any member may nominate a candidate, or self-nominate. Nominations must be announced to the membership three weeks before the AGM.
+1. The Project Leader will be elected every two years by Gem Cooperative members in a [Schulze Condorcet method](https://en.wikipedia.org/wiki/Schulze_method) (aka 'beatpath') election. The PLC will nominate at least one candidate for Project Leader. Any member may nominate a candidate, or self-nominate. Nominations must be announced to the membership three weeks before the AGM.
 
 1. In case of a casual vacancy of the Project Leader, an interim will be appointed by a supermajority vote of the PLC. In that moment, the usual membership voting and selection process will start to choose a new permament PL. If the PLC cannot reach supermajority consensus to choose an interim, the position will remain vacant until the membership chooses a new PL.
 
@@ -89,7 +89,7 @@
 
 1. The Project Leader must be a maintainer, not just a member.
 
-1. The Project Leader will be an "Owner" of the Gem.coop GitHub Organization, Bundler Slack and any related resources.
+1. The Project Leader will be an "Owner" of the gem-coop GitHub Organization, Bundler Slack and any related resources.
 
 ## 5. Technical Steering Committee
 
@@ -115,12 +115,12 @@
 
 1. New maintainers can be nominated by any existing maintainer. To become a maintainer, a nomination requires approval from the PL or any member of the TSC with no opposition from any of these people within a 1 week period. If there is opposition, the TSC must vote on the nomination in the #gem-coop-tsc private Bundler Slack channel, with the vote closing after one week or after the outcome of the vote would not be changed by any subsequent votes (such as when a majority of the TSC has voted in favour or against). The nomination will succeed by a simple majority vote of the votes cast.
 
-1. In accordance with Gem.coop's organisational security posture, which requires operating under the principle of least privilege, the PL will review maintainers' write/commit access no later than six weeks before the AGM. The PL will remove maintainer privileges from those who have not consistently met these criteria:
+1. In accordance with Gem Cooperative's organisational security posture, which requires operating under the principle of least privilege, the PL will review maintainers' write/commit access no later than six weeks before the AGM. The PL will remove maintainer privileges from those who have not consistently met these criteria:
 
 - having more contributions to primary repositories than the majority of non-maintainer contributors in at least one of these repositories
 - reviewing and merging of PRs of other maintainers and contributors in primary repositories
   - the PL will exclude from consideration non-essential pull requests submitted and merged by the same person
-- reviewing any direct GitHub review requests in any repository in the Gem.coop organisation
+- reviewing any direct GitHub review requests in any repository in the gem-coop organisation
 - responding to direct mentions on GitHub and direct mentions in Bundler Slack from the PL and other maintainers
 - maintaining a positive working relationship with the PL and other maintainers
 - engaging actively to resolve conflict with the PL or other maintainers, with a neutral intermediary upon request
@@ -129,9 +129,9 @@
 
 1. The PL will not consider the following activities because they do not require commit or write access on security-critical repositories:
 
-- contributions to the wider Gem.coop organisation, repositories excluding the main, security-critical repositories, or the greater Gem.coop ecosystem
+- contributions to the wider gem-coop organisation, repositories excluding the main, security-critical repositories, or the greater Gem Cooperative ecosystem
 - contributions in previous years as a maintainer or contributor
-- contributions to the governance documents, the PLC, social media, Gem.coop's discussion forum, etc.
+- contributions to the governance documents, the PLC, social media, Gem Cooperative's discussion forum, etc.
 
 ### 6.1 Maintainer Appeals
 
@@ -149,7 +149,7 @@
 
 ### 6.2 Emergency Removals
 
-1. In emergency situations, including but not limited to malicious commits, suspicious activity, abuse of resources, abuse of privileges, or any action or activity that could harm the security posture or reputation of the Gem.coop codebase, systems, or organisation, the PL or anyone with the capability to remove privileges should remove any or all of a maintainer's access rights (e.g. to GitHub, Bundler Slack, etc.).
+1. In emergency situations, including but not limited to malicious commits, suspicious activity, abuse of resources, abuse of privileges, or any action or activity that could harm the security posture or reputation of The Gem Cooperative codebases, systems, or organisation, the PL or anyone with the capability to remove privileges should remove any or all of a maintainer's access rights (e.g. to GitHub, Bundler Slack, etc.).
 
 1. Upon doing so, the remover must immediately inform the PLC and the TSC.
 

--- a/New-Maintainer-Checklist.md
+++ b/New-Maintainer-Checklist.md
@@ -1,9 +1,9 @@
 # New Maintainer Checklist
 
 **Existing maintainers and project leadership uses this guide to invite and onboard new maintainers and project leaders.**
-**General Gem.coop users might find it interesting but there's nothing here _users_ should have to know.**
+**General users of the gem.coop service might find it interesting but there's nothing here _users_ should have to know.**
 
-- [Gem.coop Maintainers](#maintainers)
+- [Maintainers](#maintainers)
 - [Project Leadership Committee](#plc)
 - [Technical Steering Committee](#tsc)
 - [Owners](#owners)
@@ -11,32 +11,32 @@
 
 ## Maintainers
 
-There's someone who has been making consistently high-quality contributions to Gem.coop? Let's invite them to be a maintainer!
+There's someone who has been making consistently high-quality contributions to Gem Cooperative? Let's invite them to be a maintainer!
 
 First, send them an invitation or have a discussion on a channel of your choice. Here's a sample invitation email:
 
 ```markdown
-The Gem.coop team and I really appreciate your help on issues, pull requests and
-your contributions to Gem.coop.
+The Gem Cooperative team and I really appreciate your help on issues, pull requests and
+your contributions to our projects.
 
 We would like to invite you to have commit access and be a Gem.coop maintainer.
 If you agree to be a maintainer, you should spend the majority of the time you
-are working on Gem.coop (in descending order of priority):
+are working on The Gem Cooperative (in descending order of priority):
 
 - reviewing pull requests (from users and other maintainers)
 - triaging, debugging and fixing user-reported issues and applying
 - opening PRs for widely used changes (e.g. version updates)
 
-You should also be making contributions to Gem.coop at least once per quarter.
+You should also be making contributions to Gem Cooperative at least once per quarter.
 
-You should watch or regularly check Gem.coop GitHub repositories.
+You should watch or regularly check Gem Cooperative GitHub repositories.
 
 If you're no longer able to perform all of these tasks, please continue to
-contribute to Gem.coop, but we will ask you to step down as a maintainer.
+contribute to Gem Cooperative, but we will ask you to step down as a maintainer.
 
 A few requests:
 
-- Please make pull requests for any changes in the Gem.coop repositories (instead
+- Please make pull requests for any changes in the Gem Cooperative repositories (instead
   of committing directly) and don't merge them unless you get at least one approval
   and passing tests.
 - Create branches in the main repository rather than on your fork to ease collaboration
@@ -55,19 +55,19 @@ If they accept, follow a few steps to get them set up:
 - Invite them as a full member to the [Bundler Slack](https://bundler.slack.com/admin/invites) and ask them to use their real name there (rather than a pseudonym they may use on e.g. GitHub).
 - Ask them to disable SMS as a 2FA device or fallback on their GitHub account in favour of using one of the other authentication methods.
 - Ask them to (regularly) review and remove any unneeded [GitHub personal access tokens](https://github.com/settings/tokens).
-- Start the process to [add them as Gem.coop members](#members), for formal voting rights and the ability to hold office for Gem.coop.
+- Start the process to [add them as Gem Cooperative members](#members), for formal voting rights and the ability to hold office for Gem Cooperative.
 
 If there are problems, ask them to step down as a maintainer.
 
 When they cease to be a maintainer for any reason, revoke their access to all of the above.
 
-In the interests of loosely verifying maintainer identity and building camaraderie, if you find yourself in the same town (e.g living, visiting or at a conference) as another Gem.coop maintainer you should make the effort to meet up. If you do so, you can [expense your meal](https://docs.opencollective.com/help/expenses-and-getting-paid/submitting-expenses) (within [Gem.coop's reimbursable expense policies](https://opencollective.com/gem-coop/expenses)). This is a more relaxed version of similar policies used by other projects, e.g. the Debian system to meet in person to sign keys with legal ID verification.
+In the interests of loosely verifying maintainer identity and building camaraderie, if you find yourself in the same town (e.g living, visiting or at a conference) as another Gem Cooperative maintainer you should make the effort to meet up. If you do so, you can [expense your meal](https://docs.opencollective.com/help/expenses-and-getting-paid/submitting-expenses) (within [Gem Cooperative's reimbursable expense policies](https://opencollective.com/gem-coop/expenses)). This is a more relaxed version of similar policies used by other projects, e.g. the Debian system to meet in person to sign keys with legal ID verification.
 
 Now sit back, relax and let the new maintainers handle more of our contributions.
 
 ## PLC
 
-If a maintainer or member is elected to the Gem.coop's [Project Leadership Committee](Gem.coop-Governance.md#4-project-leadership-committee):
+If a maintainer or member is elected to the Gem Cooperative's [Project Leadership Committee](Gem.coop-Governance.md#4-project-leadership-committee):
 
 - Invite them to the [**@gem-coop/plc** team](https://github.com/orgs/gem-coop/teams/plc/members)
 - Make them [billing managers](https://github.com/organizations/gem-coop/settings/billing) and [moderators](https://github.com/organizations/gem-coop/settings/moderators) on the `gem-coop` GitHub organisation
@@ -76,7 +76,7 @@ When they cease to be a PLC member, revoke or downgrade their access to all of t
 
 ## TSC
 
-If a maintainer is elected to the Gem.coop's [Technical Steering Committee](Gem.coop-Governance.md#7-technical-steering-committee):
+If a maintainer is elected to the Gem Cooperative's [Technical Steering Committee](Gem.coop-Governance.md#7-technical-steering-committee):
 
 - Invite them to the [**@gem-coop/tsc** team](https://github.com/orgs/gem-coop/teams/tsc/members)
 - Make them [billing managers](https://github.com/organizations/gem-coop/settings/billing) on the `gem-coop` GitHub organisation
@@ -94,11 +94,11 @@ When they cease to be an owner, revoke or downgrade their access to all of the a
 
 ## Members
 
-People who are either not eligible or willing to be Gem.coop maintainers but have shown continued involvement in the Gem.coop community may be admitted by a majority vote of the [Project Leadership Committee](Gem.coop-Governance.md#4-project-leadership-committee).
+People who are either not eligible or willing to be Gem Cooperative maintainers but have shown continued involvement in the Gem Cooperative community may be admitted by a majority vote of the [Project Leadership Committee](Gem.coop-Governance.md#4-project-leadership-committee).
 
 When admitted as members:
 
 - Invite them as a private member of the #gem-coop-members channel on the [Bundler Slack](https://bundler.slack.com/admin/invites) and ask them to use their real name there (rather than a pseudonym they may use on e.g. GitHub).
 - Add them to the current year's membership list in the [governance repository](https://github.com/gem-coop/governance).
 
-See [Gem.coop Governance](Gem.coop-Governance.md) for when an individual's membership expires.
+See [Gem Cooperative Governance](Gem.coop-Governance.md) for when an individual's membership expires.

--- a/README.md
+++ b/README.md
@@ -1,25 +1,25 @@
-# 👩‍⚖️ Gem.coop Governance
+# Gem Cooperative Governance
 
-- [Bootstrapping Gem.Coop Governance](Bootstrapping-Gem.coop-Governance.md)
-- [Gem.Coop Governance](Gem.coop-Governance.md)
-- [Gem.Coop Leadership Responsibilities](Gem.coop-Leadership-Responsibilities.md)
+- [Bootstrapping Gem Cooperative Governance](Bootstrapping-Gem.coop-Governance.md)
+- [Gem Cooperative Governance](Gem.coop-Governance.md)
+- [Gem Cooperative Leadership Responsibilities](Gem.coop-Leadership-Responsibilities.md)
 - [New Maintainer Checklist](New-Maintainer-Checklist.md)
 
 ## Related Resources
 
-- [Gem.coop's OpenCollective](https://opencollective.com/gem-coop)
+- [Gem Cooperative's OpenCollective](https://opencollective.com/gem-coop)
 - [Bundler's Slack](https://bundler.slack.com) (contains `gem-coop` prefixed channels)
 
 ## Who We Are
 
-Gem.coop's governance was initially guided by [Mike McQuaid](https://github.com/MikeMcQuaid).
+Gem Cooperative's governance was initially guided by [Mike McQuaid](https://github.com/MikeMcQuaid).
 
-Gem.coop's [Project Leader](Gem.coop-Governance.md#6-project-leader) is not yet elected.
+Gem Cooperative's [Project Leader](Gem.coop-Governance.md#6-project-leader) is not yet elected.
 
-Gem.coop's [Project Leadership Committee](Gem.coop-Governance.md#4-project-leadership-committee) is not yet elected.
-Gem.coop's [Technical Steering Committee](Gem.coop-Governance.md#7-technical-steering-committee) is not yet elected.
+Gem Cooperative's [Project Leadership Committee](Gem.coop-Governance.md#4-project-leadership-committee) is not yet elected.
+Gem Cooperative's [Technical Steering Committee](Gem.coop-Governance.md#7-technical-steering-committee) is not yet elected.
 
-Gem.coop's maintainers are not yet appointed.
+Gem Cooperative's maintainers are not yet appointed.
 
 ## License
 


### PR DESCRIPTION
We were frequently using `gem.coop` to refer to service, the GitHub organization, _and_ the cooperative itself.

In an attempt to avoid confusion, I did my best to clarify the distinction between:

- `gem.coop` (the service/website)
- Gem Cooperative (the group)
- `gem-coop` (the GitHub organization)